### PR TITLE
Updated RELEASE to pull the correct ap version and added support for Ubuntu 24

### DIFF
--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -3,7 +3,7 @@ APPNAME:=epicsarchiverap
 
 ## Where the Source repository SRC_URL/SRC_NAME
 #
-SRC_URL:=https://github.com/jeonghanlee
+SRC_URL:=https://github.com/archiver-appliance
 SRC_NAME:=${APPNAME}
 
 
@@ -14,10 +14,10 @@ SRC_NAME:=${APPNAME}
 #SRC_TAG:=734f31f
 ## Placeholder for the site-specific version control 
 #
-SRC_TAG:=d3dd9cc
+SRC_TAG:=92c7e77
 #
 #SRC_VERSION:=$(SRC_TAG)
-SRC_VERSION:=${SRC_TAG}-2022-08-08
+SRC_VERSION:=${SRC_TAG}-2025-03-02
 
 -include $(TOP)/../RELEASE.local
 -include $(TOP)/configure/RELEASE.local

--- a/scripts/required_pkgs.sh
+++ b/scripts/required_pkgs.sh
@@ -250,6 +250,7 @@ case "$dist" in
     *buster*)   debian10_pkgs ;;
     *bullseye*) debian11_pkgs ;;
     *bookworm*) debian12_pkgs ;;
+    *noble*)    debian12_pkgs ;; # noble is actualy ubuntu 24.04 but the commands should be the same
     *CentOS* | *Scientific* ) 
         centos_version=$(centos_dist)
         if [ "$centos_version" == "7" ]; then


### PR DESCRIPTION
Thank you for your contribution, you helped me a lot.

I had to make these minor changes for the build to work for me, maybe that will help someone.

- make init now pulls the archiver-appliance version from 2025-03-02 - the original files pulled the jeonghanlee fork of older version that doesn't use gradle
- Added support for Ubuntu 24.04. - not in a classy way but now it works.

Thank you for considering the request.